### PR TITLE
Fix grades details

### DIFF
--- a/app/src/main/kotlin/ca/etsmtl/etsmobile/presentation/gradesdetails/EvaluationHeaderItem.kt
+++ b/app/src/main/kotlin/ca/etsmtl/etsmobile/presentation/gradesdetails/EvaluationHeaderItem.kt
@@ -28,7 +28,7 @@ import kotlinx.android.synthetic.main.item_evaluation_header.tvWeight
  */
 class EvaluationHeaderItem(private val evaluation: Evaluation) : Item(), ExpandableItem {
     private lateinit var expandableGroup: ExpandableGroup
-    private var dataSet = false
+    private var animatedProgress = false
     private val rotateArrowToTop by lazy {
         RotateAnimation(
             0f, -180f,
@@ -54,8 +54,12 @@ class EvaluationHeaderItem(private val evaluation: Evaluation) : Item(), Expanda
     override fun getLayout() = R.layout.item_evaluation_header
 
     override fun bind(viewHolder: ViewHolder, position: Int) {
-        if (dataSet) {
-            return
+        fun setProgressColor(progress: Float) {
+            with (viewHolder.progressViewGrade) {
+                val color = progressColor(context, progress)
+                setStartColor(color)
+                setEndColor(color)
+            }
         }
 
         with (viewHolder) {
@@ -85,18 +89,23 @@ class EvaluationHeaderItem(private val evaluation: Evaluation) : Item(), Expanda
                 }
 
                 setEndProgress(grade)
-                setProgressViewUpdateListener(object : CircleProgressView.CircleProgressUpdateListener {
-                    override fun onCircleProgressFinished(view: View) {}
 
-                    override fun onCircleProgressStart(view: View) {}
+                if (animatedProgress) {
+                    progress = grade
+                    setProgressColor(grade)
+                } else {
+                    setProgressViewUpdateListener(object : CircleProgressView.CircleProgressUpdateListener {
+                        override fun onCircleProgressFinished(view: View) {}
 
-                    override fun onCircleProgressUpdate(view: View, progress: Float) {
-                        val color = progressColor(context, progress)
-                        setStartColor(color)
-                        setEndColor(color)
-                    }
-                })
-                startProgressAnimation()
+                        override fun onCircleProgressStart(view: View) {}
+
+                        override fun onCircleProgressUpdate(view: View, progress: Float) {
+                            setProgressColor(progress)
+                        }
+                    })
+                    startProgressAnimation()
+                    animatedProgress = true
+                }
             }
 
             tvIgnoredEvaluation.show(evaluation.ignoreDuCalcul)
@@ -118,8 +127,6 @@ class EvaluationHeaderItem(private val evaluation: Evaluation) : Item(), Expanda
                     else -> arrow.startAnimation(rotateArrowToBottom)
                 }
             }
-
-            dataSet = true
         }
     }
 

--- a/app/src/main/kotlin/ca/etsmtl/etsmobile/presentation/gradesdetails/GradeAverageItem.kt
+++ b/app/src/main/kotlin/ca/etsmtl/etsmobile/presentation/gradesdetails/GradeAverageItem.kt
@@ -18,13 +18,9 @@ class GradeAverageItem(
     private val gradePercentage: String?,
     private val average: String?
 ) : Item() {
-    private var dataSet = false
+    private var animatedProgress = false
 
     override fun bind(viewHolder: ViewHolder, position: Int) {
-        if (dataSet) {
-            return
-        }
-
         with (viewHolder) {
             tvRating.text = rating
 
@@ -34,7 +30,7 @@ class GradeAverageItem(
                         gradePercentage
                 )
             }
-            setCircleProgressViewProgress(progressViewGrade, gradePercentage)
+            setCircleProgressViewProgress(progressViewGrade, gradePercentage, !animatedProgress)
 
             tvAverage.apply {
                 text = String.format(
@@ -42,19 +38,29 @@ class GradeAverageItem(
                         average
                 )
             }
-            setCircleProgressViewProgress(progressViewAverage, average)
+            setCircleProgressViewProgress(progressViewAverage, average, !animatedProgress)
 
-            dataSet = true
+            animatedProgress = true
         }
     }
 
     override fun getLayout() = R.layout.item_grade_average
 
-    private fun setCircleProgressViewProgress(circleProgressView: CircleProgressView, progress: String?) {
+    private fun setCircleProgressViewProgress(
+        circleProgressView: CircleProgressView,
+        progress: String?,
+        animate: Boolean
+    ) {
         progress?.let {
             with(circleProgressView) {
-                setEndProgress(it.replace(",", ".").toFloat())
-                startProgressAnimation()
+                val progressFloat = it.replace(",", ".").toFloat()
+                setEndProgress(progressFloat)
+
+                if (animate) {
+                    startProgressAnimation()
+                } else {
+                    this.progress = progressFloat
+                }
             }
         }
     }


### PR DESCRIPTION
The view was not binded properly when scrolling to the bottom. Wrong items were being displayed.

Use a boolean only for the animation. When scrolling down the user should see the progress animation and not when scrolling up.