### PR TITLE
Make the course argument optional for fetching Seances

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -24,7 +24,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,6 @@ buildscript {
     ext.flexbox = '1.0.0'
     ext.glide = '4.8.0'
     ext.groupie = '2.1.0'
-    ext.hyperion = '0.9.24'
     ext.junit = '4.12'
     ext.kotlin_version = '1.2.71'
     ext.kotshi = '1.0.2'

--- a/repository/src/androidTest/kotlin/ca/etsmtl/applets/repository/data/db/signets/SeanceDaoTest.kt
+++ b/repository/src/androidTest/kotlin/ca/etsmtl/applets/repository/data/db/signets/SeanceDaoTest.kt
@@ -14,8 +14,8 @@ import org.junit.Test
  */
 class SeanceDaoTest : DbTest() {
     private val entity = SeanceEntity(
-            "/Date(1525093200000)/",
-            "/Date(1525105800000)/",
+            1525093200000,
+            1525105800000,
             "Cours",
             "B-0904",
             "Activité de cours",
@@ -41,8 +41,8 @@ class SeanceDaoTest : DbTest() {
     @Test
     fun testInsertSame() {
         val same = SeanceEntity(
-                "/Date(1525093200000)/",
-                "/Date(1527950896000)/",
+                1525093200000,
+                1527950896000,
                 "Cours",
                 "B-0904",
                 "Activité de cours",
@@ -58,8 +58,8 @@ class SeanceDaoTest : DbTest() {
     @Test
     fun testByCoursAndSession() {
         val expected = SeanceEntity(
-                "/Date(1525093200123)/",
-                "/Date(1527950896022)/",
+                1525093200123,
+                1527950896022,
                 "Cours",
                 "B-0904",
                 "Activité de cours",
@@ -70,8 +70,8 @@ class SeanceDaoTest : DbTest() {
         dao.insert(expected)
 
         val unexpected1 = SeanceEntity(
-                "/Date(1525093200000)/",
-                "/Date(1527950896000)/",
+                1525093200000,
+                1527950896000,
                 "Cours",
                 "B-0904",
                 "Activité de cours",
@@ -82,8 +82,8 @@ class SeanceDaoTest : DbTest() {
         dao.insert(unexpected1)
 
         val unexpected2 = SeanceEntity(
-                "/Date(1525093200000)/",
-                "/Date(1527950896000)/",
+                1525093200000,
+                1527950896000,
                 "Cours",
                 "B-0904",
                 "Activité de cours",
@@ -102,11 +102,64 @@ class SeanceDaoTest : DbTest() {
     }
 
     @Test
+    fun testBySession() {
+        val expected = SeanceEntity(
+                1525093200123,
+                1527950896022,
+                "Cours",
+                "B-0904",
+                "Activité de cours",
+                "Algèbre linéaire et géométrie de l'espace",
+                "MAT472",
+                "A2018"
+        )
+        dao.insert(expected)
+
+        val expected2 = SeanceEntity(
+                1525093200000,
+                1527950896000,
+                "Cours",
+                "B-0904",
+                "Activité de cours",
+                "Foo",
+                "LOG123",
+                expected.session
+        )
+        dao.insert(expected2)
+
+        val unexpected1 = SeanceEntity(
+                1525093200000,
+                1527950896000,
+                "Cours",
+                "B-0904",
+                "Activité de cours",
+                "Foo",
+                expected.sigleCours,
+                "E2018"
+        )
+        dao.insert(unexpected1)
+
+        val seances = LiveDataTestUtil.getValue(dao.getBySession(expected.session))
+        assertEquals(2, seances.size)
+        assertEquals(expected, seances[0])
+        assertEquals(expected2, seances[1])
+    }
+
+    @Test
     fun testDeleteByCoursAndSession() {
         dao.deleteByCoursAndSession(entity.sigleCours, "A2018")
         assertEquals(1, LiveDataTestUtil.getValue(dao.getAll()).size)
 
         dao.deleteByCoursAndSession("LOG123", entity.session)
+        assertEquals(1, LiveDataTestUtil.getValue(dao.getAll()).size)
+
+        dao.deleteByCoursAndSession(entity.sigleCours, entity.session)
+        assertEquals(0, LiveDataTestUtil.getValue(dao.getAll()).size)
+    }
+
+    @Test
+    fun testDeleteBySession() {
+        dao.deleteByCoursAndSession(entity.sigleCours, "A2018")
         assertEquals(1, LiveDataTestUtil.getValue(dao.getAll()).size)
 
         dao.deleteByCoursAndSession(entity.sigleCours, entity.session)

--- a/repository/src/androidTest/kotlin/ca/etsmtl/applets/repository/data/db/signets/SeanceDaoTest.kt
+++ b/repository/src/androidTest/kotlin/ca/etsmtl/applets/repository/data/db/signets/SeanceDaoTest.kt
@@ -116,7 +116,7 @@ class SeanceDaoTest : DbTest() {
         dao.insert(expected)
 
         val expected2 = SeanceEntity(
-                1525093200000,
+                1525093300000,
                 1527950896000,
                 "Cours",
                 "B-0904",

--- a/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/api/response/mapper/SignetsApiMapperExt.kt
+++ b/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/api/response/mapper/SignetsApiMapperExt.kt
@@ -26,6 +26,7 @@ import ca.etsmtl.applets.repository.data.db.entity.signets.SommaireElementsEvalu
 import ca.etsmtl.applets.repository.data.db.entity.signets.SessionEntity
 import ca.etsmtl.applets.repository.data.model.Cours
 import ca.etsmtl.applets.repository.data.model.Session
+import ca.etsmtl.applets.repository.util.msDateToUnix
 import ca.etsmtl.applets.repository.util.replaceCommaAndParseToDouble
 import ca.etsmtl.applets.repository.util.replaceCommaAndParseToFloat
 import ca.etsmtl.applets.repository.util.toLocaleDate
@@ -179,18 +180,18 @@ fun ApiListeJoursRemplaces.toJourRemplaceEntities(session: Session): List<JourRe
     return null
 }
 
-fun ApiSeance.toSeanceEntity(cours: Cours) = SeanceEntity(
-        this.dateDebut,
-        this.dateFin,
-        this.nomActivite,
-        this.local,
-        this.descriptionActivite,
-        this.libelleCours,
-        cours.sigle,
-        cours.session
+fun ApiSeance.toSeanceEntity(session: String) = SeanceEntity(
+        dateDebut.msDateToUnix(),
+        dateFin.msDateToUnix(),
+        nomActivite,
+        local,
+        descriptionActivite,
+        libelleCours,
+        coursGroupe.substringBefore("-"),
+        session
 )
 
-fun ApiListeDesSeances.toSeancesEntities(cours: Cours): List<SeanceEntity> = liste.map { it.toSeanceEntity(cours) }
+fun ApiListeDesSeances.toSeancesEntities(session: String): List<SeanceEntity> = liste.map { it.toSeanceEntity(session) }
 
 fun ApiSession.toSessionEntity() = SessionEntity(
         abrege,

--- a/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/db/dao/signets/SeanceDao.kt
+++ b/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/db/dao/signets/SeanceDao.kt
@@ -17,12 +17,24 @@ abstract class SeanceDao : SignetsDao<SeanceEntity> {
     @Query("SELECT * FROM seanceentity WHERE sigleCours LIKE :sigleCours AND session LIKE :session")
     abstract fun getByCoursAndSession(sigleCours: String, session: String): LiveData<List<SeanceEntity>>
 
+    @Query("SELECT * FROM seanceentity WHERE session LIKE :session")
+    abstract fun getBySession(session: String): LiveData<List<SeanceEntity>>
+
     @Query("DELETE FROM seanceentity WHERE sigleCours LIKE :sigleCours  AND session LIKE :session")
     abstract fun deleteByCoursAndSession(sigleCours: String, session: String)
+
+    @Query("DELETE FROM seanceentity WHERE session LIKE :session")
+    abstract fun deleteBySession(session: String)
 
     @Transaction
     open fun clearAndInsertByCoursAndSession(sigleCours: String, session: String, seances: List<SeanceEntity>) {
         deleteByCoursAndSession(sigleCours, session)
+        insertAll(seances)
+    }
+
+    @Transaction
+    open fun clearAndInsertBySession(session: String, seances: List<SeanceEntity>) {
+        deleteBySession(session)
         insertAll(seances)
     }
 }

--- a/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/db/entity/mapper/SignetsDbMapperExt.kt
+++ b/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/db/entity/mapper/SignetsDbMapperExt.kt
@@ -16,6 +16,7 @@ import ca.etsmtl.applets.repository.data.model.JourRemplace
 import ca.etsmtl.applets.repository.data.model.Seance
 import ca.etsmtl.applets.repository.data.model.SommaireElementsEvaluation
 import ca.etsmtl.applets.repository.data.model.Session
+import java.util.*
 
 /**
  * Created by Sonphil on 09-07-18.
@@ -86,8 +87,8 @@ fun JourRemplaceEntity.toJourRemplace() = JourRemplace(
 fun List<JourRemplaceEntity>.toJoursRemplaces() = map { it.toJourRemplace() }
 
 fun SeanceEntity.toSeance() = Seance(
-        this.dateDebut,
-        this.dateFin,
+        Date(dateDebut),
+        Date(dateFin),
         this.nomActivite,
         this.local,
         this.descriptionActivite,

--- a/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/db/entity/mapper/SignetsDbMapperExt.kt
+++ b/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/db/entity/mapper/SignetsDbMapperExt.kt
@@ -16,7 +16,7 @@ import ca.etsmtl.applets.repository.data.model.JourRemplace
 import ca.etsmtl.applets.repository.data.model.Seance
 import ca.etsmtl.applets.repository.data.model.SommaireElementsEvaluation
 import ca.etsmtl.applets.repository.data.model.Session
-import java.util.*
+import java.util.Date
 
 /**
  * Created by Sonphil on 09-07-18.

--- a/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/db/entity/signets/SeanceEntity.kt
+++ b/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/db/entity/signets/SeanceEntity.kt
@@ -6,8 +6,8 @@ import android.arch.persistence.room.PrimaryKey
 @Entity
 data class SeanceEntity(
     @PrimaryKey
-    var dateDebut: String,
-    var dateFin: String,
+    var dateDebut: Long,
+    var dateFin: Long,
     var nomActivite: String,
     var local: String,
     var descriptionActivite: String,

--- a/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/model/Seance.kt
+++ b/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/model/Seance.kt
@@ -1,14 +1,14 @@
 package ca.etsmtl.applets.repository.data.model
 
-import java.util.*
+import java.util.Date
 
 data class Seance(
-        var dateDebut: Date,
-        var dateFin: Date,
-        var nomActivite: String,
-        var local: String,
-        var descriptionActivite: String,
-        var libelleCours: String,
-        var sigleCours: String,
-        var session: String
+    var dateDebut: Date,
+    var dateFin: Date,
+    var nomActivite: String,
+    var local: String,
+    var descriptionActivite: String,
+    var libelleCours: String,
+    var sigleCours: String,
+    var session: String
 )

--- a/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/model/Seance.kt
+++ b/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/model/Seance.kt
@@ -1,12 +1,14 @@
 package ca.etsmtl.applets.repository.data.model
 
+import java.util.*
+
 data class Seance(
-    var dateDebut: String,
-    var dateFin: String,
-    var nomActivite: String,
-    var local: String,
-    var descriptionActivite: String,
-    var libelleCours: String,
-    var sigleCours: String,
-    var session: String
+        var dateDebut: Date,
+        var dateFin: Date,
+        var nomActivite: String,
+        var local: String,
+        var descriptionActivite: String,
+        var libelleCours: String,
+        var sigleCours: String,
+        var session: String
 )

--- a/repository/src/main/kotlin/ca/etsmtl/applets/repository/util/StringExt.kt
+++ b/repository/src/main/kotlin/ca/etsmtl/applets/repository/util/StringExt.kt
@@ -51,3 +51,8 @@ fun String.toLocaleDate(): String {
         }
     }
 }
+
+/**
+ * Formats Microsoft JSON date (e.g. /Date(1525093200000)/) to Unix time (e.g. 1525093200000)
+ */
+fun String.msDateToUnix() = substringAfter('(').substringBefore(')').toLong()


### PR DESCRIPTION
When fetching the Seances, the course field is not mandatory. If it's empty, the Seances will be fetched only by session.

Also, converted Seance model's Microsoft date